### PR TITLE
Fix Core class throwing in static .ctor

### DIFF
--- a/Core.cs
+++ b/Core.cs
@@ -41,7 +41,7 @@ namespace Satchel
             }
         }
         static Core(){
-            Satchel.Instance.Log(AssemblyUtils.Version());
+            Modding.Logger.Log(AssemblyUtils.Version());
             LoadShaders();
         }
 

--- a/Core.cs
+++ b/Core.cs
@@ -41,7 +41,6 @@ namespace Satchel
             }
         }
         static Core(){
-            Modding.Logger.Log(AssemblyUtils.Version());
             LoadShaders();
         }
 


### PR DESCRIPTION
Static constructors can't rely on `Satchel.Instance`.